### PR TITLE
Syntax error lib/acts_as_voteable.rb:62

### DIFF
--- a/lib/acts_as_voteable.rb
+++ b/lib/acts_as_voteable.rb
@@ -59,8 +59,7 @@ module ThumbsUp
         t = t.where("joined_#{Vote.table_name}.created_at >= ?", options[:start_at]) if options[:start_at]
         t = t.where("joined_#{Vote.table_name}.created_at <= ?", options[:end_at]) if options[:end_at]
         t = t.where(options[:conditions]) if options[:conditions]
-        t = options[:ascending] ? t.order("joined_#{Vote.table_name}.Vote_Total")
-	                                  : t.order("joined_#{Vote.table_name}.Vote_Total DESC")
+        t = options[:ascending] ? t.order("joined_#{Vote.table_name}.Vote_Total") : t.order("joined_#{Vote.table_name}.Vote_Total DESC")
 			  
         t = t.having(["COUNT(joined_#{Vote.table_name}.voteable_id) > 0",
 	        (options[:at_least] ? "joined_votes.Vote_Total >= #{sanitize(options[:at_least])}" : nil),


### PR DESCRIPTION
Hey Brady8,

Nice work on this library!

I just noticed I'd get a small error every time from acts_as_voteable:rb:62

Maybe the version of ruby I'm using doesn't allow a \n during ternary notation? 

In either case, it was a small fix. I just put it all on one line.

Cheers,

Oliver Ponder
