### PR TITLE
Generated sql for plusminus_tally is invalid in SQLite

### DIFF
--- a/lib/acts_as_voteable.rb
+++ b/lib/acts_as_voteable.rb
@@ -32,6 +32,10 @@ module ThumbsUp
           table = "CAST(#{Vote.table_name}.vote AS UNSIGNED)"
           true_value = '1'
           false_value = '0'
+        elsif sqlite?
+          table = "#{Vote.table_name}.vote"
+          true_value = 'votes.vote = \'true\''
+          false_value = 'votes.vote = \'false\''
         else
           table = "#{Vote.table_name}.vote"
           true_value = 'true'

--- a/lib/thumbs_up.rb
+++ b/lib/thumbs_up.rb
@@ -8,6 +8,10 @@ module ThumbsUp
     def mysql?
       ActiveRecord::Base.connection.adapter_name == 'MySQL'
     end
+
+    def sqlite?
+      ActiveRecord::Base.connection.adapter_name == 'SQLite'
+    end
   end
 end
 


### PR DESCRIPTION
Error message is:
`ActiveRecord::StatementInvalid: SQLite3::SQLException: no such column: true: SELECT  songs.*, SUM(CASE votes.vote WHEN true THEN 1 WHEN false THEN -1 ELSE 0 END) AS plusminus_tally, COUNT(votes.id) AS vote_count FROM "songs" LEFT OUTER JOIN votes ON songs.id = votes.voteable_id AND votes.voteable_type = 'Song' WHERE "songs"."event_id" = 1 GROUP BY songs.id ORDER BY plusminus_tally DESC, plusminus_tally LIMIT 1`

Changed the code in CASE to be:

`CASE votes.vote WHEN votes.vote = 'true' THEN 1 WHEN votes.vote = 'false' THEN -1 ELSE 0 END`

I also added another helper method to detect sqlite.
