### PR TITLE
Tally totals without ordering

### DIFF
--- a/lib/acts_as_voteable.rb
+++ b/lib/acts_as_voteable.rb
@@ -17,6 +17,16 @@ module ThumbsUp
 
     module SingletonMethods
 
+      # Useful for when you want to efficiently get plusminus totals in a single DB query without any ordering
+      def with_plusminus
+        plusminus_tally(:disable_ordering => true)
+      end
+      
+      # Useful for when you want to efficiently get vote totals in a single DB query without any ordering
+      def with_votes
+        tally(:disable_ordering => true)
+      end
+
       # Calculate the plusminus for a group of voteables in one database query.
       # This returns an Arel relation, so you can add conditions as you like chained on to
       # this method call.
@@ -49,9 +59,11 @@ module ThumbsUp
       # This returns an Arel relation, so you can add conditions as you like chained on to
       # this method call.
       # i.e. Posts.tally.where('votes.created_at > ?', 2.days.ago)
-      def tally(*args)
+      def tally(params = {})
         t = self.joins("LEFT OUTER JOIN #{Vote.table_name} ON #{self.table_name}.id = #{Vote.table_name}.voteable_id")
-        t = t.order("vote_count DESC")
+        unless params[:disable_ordering]
+          t = t.order("vote_count DESC")
+        end
         t = t.group(column_names_for_tally)
         t = t.select("#{self.table_name}.*")
         t = t.select("COUNT(#{Vote.table_name}.id) AS vote_count")


### PR DESCRIPTION
I've noticed that `#plusminus_tally` and `#tally` sorts the JOIN'd table and clobbers my preferred ordering (just efficiently JOIN the votes and totals and only sort by date DESC).

I wrote `#with_plusminus` and `#with_votes` for those who just want to take advantage of the efficient query to obtain the thumbs_up attributes without ordering anything.

So this now sorts only by created_at DESC:

``` ruby
Post.with_plusminus.order('created_at DESC').map{|x|[x.created_at, x.plusminus]}
=> [[Thu, 17 Jan 2013 19:59:20 UTC +00:00, 0], [Sat, 08 Dec 2012 20:16:22 UTC +00:00, 0], [Tue, 27 Nov 2012 06:08:36 UTC +00:00, 0], [Tue, 27 Nov 2012 06:07:21 UTC +00:00, 1]]
```

Where, currently, this sorts by votes and clobbers my order call:

``` ruby
Post.plusminus_tally.order('created_at DESC').map{|x|[x.created_at, x.plusminus]}
=> [[Tue, 27 Nov 2012 06:07:21 UTC +00:00, 1], [Thu, 17 Jan 2013 19:59:20 UTC +00:00, 0], [Sat, 08 Dec 2012 20:16:22 UTC +00:00, 0], [Tue, 27 Nov 2012 06:08:36 UTC +00:00, 0]]
```
