### PR TITLE
Fixed typo

### DIFF
--- a/lib/thumbs_up.rb
+++ b/lib/thumbs_up.rb
@@ -25,7 +25,7 @@ module ThumbsUp
     end
 
     # The configuration object.
-    # @see I18::Airbrake.configure
+    # @see ThumbsUp::Configuration
     def configuration
       @configuration ||= Configuration.new
     end


### PR DESCRIPTION
I missed another typo.  I re-used the configuration I added to I18n::Airbrake as the template - and I miseed an I18n in a comment. :(  Submitting this PR with typo fix.
