### PR TITLE
The source :rubygems is deprecated because HTTP requests are insecure.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec


### PR DESCRIPTION
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
