### PR TITLE
fix documentation typo and add documentation for the alias_method

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Usage
     voter.vote_exclusively_for(voteable)	# Removes any previous votes by that particular voter, and votes for.
     voter.vote_exclusively_against(voteable)	# Removes any previous votes by that particular voter, and votes against.
 
-    vote.unvote_for(voteable)  # Clears all votes for that user
+    voter.unvote_for(voteable)  # Clears all votes for that user
+    voter.clear_votes(voteable) # Also clears all votes
 
 ### Querying votes
 


### PR DESCRIPTION
I was quite confused whether unvote_for clear the vote for the voteable or all votes

so instead of making a new alias, I just documented the already existing alias which has clearer name

and fixed a type
