### PR TITLE
ignore text type columns from column_names_for_tally

### DIFF
--- a/lib/acts_as_voteable.rb
+++ b/lib/acts_as_voteable.rb
@@ -57,7 +57,7 @@ module ThumbsUp
       end
 
       def column_names_for_tally
-        column_names.map { |column| "#{self.table_name}.#{column}" }.join(', ')
+        column_types.select { |k,v| v.type != :text }.map { |column,_| "#{self.table_name}.#{column}" }.join(', ')
       end
 
     end


### PR DESCRIPTION
I found a bug using `kaminari` if I have a `text` type column paginationhelper  does not work

so for something like this does, `paginate` helper does not work

    Model.plusminus_tally.page(0)    

`column_names_for_tally`  includes all the columns that should be included in the group by
I changed it to exclude columns with `text` type. 

it might or it might not be a good idea, I do not know why it fails or if it should be fixed in `kaminari`

